### PR TITLE
fix: renombrar carpeta backend y agregar nombre de Rodrigo al README

### DIFF
--- a/QA-FinalProject-AutoTesting/README.md
+++ b/QA-FinalProject-AutoTesting/README.md
@@ -8,7 +8,7 @@ Este repositorio contiene el proyecto final del curso **Test Automation Engineer
 
 - [Victor Javier Vivas](https://github.com/victorvivas27) 
 - [Leonel Briones](https://github.com/jarodsmdev)
-- [Nombre 3] –
+- [Rodrigo Quiroz Castro](https://github.com/RodDev88)
 -  
 ## Documentación relacionada
 ---


### PR DESCRIPTION
Se corrige el nombre de la carpeta 'Prubas-de-Backend' a 'Pruebas-de-backend' 
y se agrega a Rodrigo Quiroz como integrante del equipo en el archivo README.md.
